### PR TITLE
part 1 : added a line to clear the player character after drawing it

### DIFF
--- a/content/tutorials/tcod/part-1.md
+++ b/content/tutorials/tcod/part-1.md
@@ -228,6 +228,8 @@ new coordinates.
 -       libtcod.console_put_char(0, 1, 1, '@', libtcod.BKGND_NONE)
 +       libtcod.console_put_char(0, player_x, player_y, '@', libtcod.BKGND_NONE)
         libtcod.console_flush()
+        
++       libtcod.console_put_char(0, player_x, player_y, ' ', libtcod.BKGND_NONE)
         ...
 {{</ highlight >}}
 {{</ diff-tab >}}
@@ -237,6 +239,8 @@ new coordinates.
         <span class="crossed-out-text">libtcod.console_put_char(0, 1, 1, '@', libtcod.BKGND_NONE)</span>
         <span class="new-text">libtcod.console_put_char(0, player_x, player_y, '@', libtcod.BKGND_NONE)</span>
         libtcod.console_flush()
+        
+        <span class="new-text">libtcod.console_put_char(0, player_x, player_y, ' ', libtcod.BKGND_NONE)</span>
         ...</pre>
 {{</ original-tab >}}
 {{</ codetab >}}


### PR DESCRIPTION
The line is removed in the last code sample but is never added prior to that.

It might make more sense to have a section where the player is able to move around but the line is absent and they leave behind a trail.
This would demonstrate why a space is put in the player's location after rendering and provide an opportunity to mention methods of clearing the console.